### PR TITLE
chore: updated the ctaSection with buttons and UX improvements

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -190,7 +190,8 @@
   "cta": {
     "ready": "Ready to Get Started?",
     "startSelling": "Start Selling",
-    "exploreProducts": "Explore Products"
+    "exploreProducts": "Explore Products",
+    "joinWaitlist" : "Join Waitlist"
   },
 
   "FarmerSubscription": {
@@ -1009,7 +1010,6 @@
     "deliveryPending": "Your order will be delivered soon.",
     "estimated": "Estimated: {date}",
     "pending": "Pending",
-    "processing": "Processing",
     "completed": "Completed",
     "cancelled": "Cancelled"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -189,10 +189,11 @@
   },
 
   "cta": {
-      "ready": "¿Listo para Comenzar?",
-      "startSelling": "Empieza a Vender",
-      "exploreProducts": "Explorar Productos"
-    },
+    "ready": "¿Listo para Comenzar?",
+    "startSelling": "Empieza a Vender",
+    "exploreProducts": "Explorar Productos",
+    "joinWaitlist": "Unirse a la Lista de Espera"
+  },
 
   "FarmerSubscription": {
     "ctaLabel": "Empezar a Vender",
@@ -587,7 +588,7 @@
           "title": "Precipitación",
           "unit": "mm"
         },
-        "growingSeason": {  
+        "growingSeason": {
           "title": "Temporada de Crecimiento",
           "unit": "días"
         }
@@ -903,4 +904,3 @@
     }
   }
 }
-

--- a/src/components/cta/CtaSection.tsx
+++ b/src/components/cta/CtaSection.tsx
@@ -1,9 +1,11 @@
-"use client";
+'use client';
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import { useLanguageStore } from '@/store/languageStore/store';
+
+const MotionLink = motion(Link);
 
 export default function CtaSection() {
   const t = useTranslations('cta');
@@ -14,23 +16,30 @@ export default function CtaSection() {
       <div className="container mx-auto px-6 text-center max-w-4xl">
         <h2 className="text-3xl md:text-4xl font-bold mb-8 text-forest-800">{t('ready')}</h2>
         <div className="flex flex-col sm:flex-row justify-center gap-4">
-          <Link
+          <MotionLink
             href={`/${language}/sales`}
-            className="inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-r from-forest-600 via-forest-500 to-forest-400 px-9 font-semibold shadow-lg border border-forest-700/70 text-white transition-all duration-300 ease-out transform-gpu hover:scale-[1.065] hover:shadow-2xl active:scale-[0.95] focus:outline-none focus-visible:ring-4 focus-visible:ring-forest-400/40"
+            className="inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-r from-forest-600 via-forest-500 to-forest-400 px-9 font-semibold shadow-lg border border-forest-700/70 text-white transition-all duration-300 ease-out transform-gpu hover:scale-[1.065] hover:shadow-2xl focus:outline-none focus-visible:ring-4 focus-visible:ring-forest-400/40"
             style={{ color: '#FFFFFF' }}
+            whileTap={{ scale: 0.95 }}
           >
             {t('startSelling')}
-          </Link>
-          <Link
+          </MotionLink>
+          <MotionLink
             href={`/${language}/marketplace`}
-            className="inline-flex h-12 items-center justify-center rounded-full bg-white px-9 text-base font-semibold text-forest-700 shadow-md border border-brand-600/40 transition-all duration-300 ease-out transform-gpu  hover:bg-brand-50 hover:text-forest-800 hover:border-forest-300 hover:shadow-2xl hover:scale-[1.065] active:scale-[0.95] focus:outline-none focus-visible:ring-4 focus-visible:ring-forest-300/40"
+            className="inline-flex h-12 items-center justify-center rounded-full bg-white px-9 text-base font-semibold text-forest-700 shadow-md border border-brand-600/40 transition-all duration-300 ease-out transform-gpu  hover:bg-brand-50 hover:text-forest-800 hover:border-forest-300 hover:shadow-2xl hover:scale-[1.065] focus:outline-none focus-visible:ring-4 focus-visible:ring-forest-300/40"
+            whileTap={{ scale: 0.95 }}
           >
             {t('exploreProducts')}
-          </Link>
+          </MotionLink>
+          <MotionLink
+            href={`/${language}/#waitlist`}
+            className="inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-b from-yellow-400 to-yellow-600 text-yellow-900 px-9 text-base font-semibold shadow-md border border-brand-600/40 transition-all duration-300 ease-out transform-gpu  hover:bg-brand-50 hover:text-forest-800 hover:border-forest-300 hover:shadow-2xl hover:scale-[1.065] focus:outline-none focus-visible:ring-4 focus-visible:ring-forest-300/40"
+            whileTap={{ scale: 0.95 }}
+          >
+            {t('joinWaitlist')}
+          </MotionLink>         
         </div>
       </div>
     </section>
   );
 }
-
-


### PR DESCRIPTION
# Pull Request Overview

## 📝 Summary
Centered section with "Ready to Get Started?" title and 3 buttons with different styles and actions.

### 🪧 Related Issues
- Closes #120 

### 🏁 Type of Change
Mark with an `x` all the checkboxes that apply (like `[x]`).

- [ ] 📝 Documentation (updates to README, docs, or comments)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 👌 Enhancement (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

### 🔄 Changes Made
- Made Changes to the `src/components/ctaSection.tsx` to add the buttons necessary
- Used Framer Motion to indicate a pressed state for the individual buttons
- Updated the language json file for spanish language

### 🚀 Implementation Details
Describe how you implemented the changes.

### 🛠 Technical Notes
Include any technical details that reviewers should be aware of.

### ✅ Tests Results
Describe the tests you performed to verify your changes:

### Test Coverage
- [ ] ✅ Unit Tests
- [ ] 📨 Integration Tests
- [x] 📟 Manual Testing

### 📸 Evidence
<img width="1919" height="550" alt="rev" src="https://github.com/user-attachments/assets/4c46b024-2b82-437b-99ef-8335876c95f8" />

### 🔍 Testing Notes
Include any special testing considerations or edge cases checked.

### 🔜 Next Steps
Indicate actions or improvements to be taken after this PR, if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Join Waitlist” call-to-action alongside existing options.
  * Added corresponding English and Spanish translations for the new CTA.
* **Style**
  * Introduced subtle tap animations on CTA buttons for a more responsive feel.
* **Changes**
  * Streamlined order status labels by removing the “Processing” status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->