### PR TITLE
feat: Add interactive gallery with accessibility and hover effects to…

### DIFF
--- a/messages/es.json
+++ b/messages/es.json
@@ -1008,6 +1008,7 @@
       "lastUsed": "Usado por última vez",
       "location": "Ubicación"
     }
+  },
   "Producers": {
     "hero": {
       "title": "Nuestros Productores",

--- a/src/components/herosection/heroSection.tsx
+++ b/src/components/herosection/heroSection.tsx
@@ -42,7 +42,7 @@ export default function HeroSection() {
               style={{ color: '#FFFFFF' }}
               className="!text-[#FFFFFF]"
             >
-              {t('exploreMarketplace')}
+              {t('exploreMarketplace')}555555555555555555
             </Link>
           </Button>
           <Button

--- a/src/components/herosection/herosectionnew.tsx
+++ b/src/components/herosection/herosectionnew.tsx
@@ -14,7 +14,7 @@ export default function HeroSectionNew() {
   const t = useTranslations('Hero');
   const tButton = useTranslations('HeroSection');
   const { language } = useLanguageStore();
-  const [expandedIndex, setExpandedIndex] = useState(0);
+  const [expandedIndex, setExpandedIndex] = useState(1);
 
   
   // Use typewriter effect for the main title with 120ms speed
@@ -31,7 +31,7 @@ setExpandedIndex(index);
 //   }
 
   function handleMouseLeave() {
-    setExpandedIndex(0);
+    setExpandedIndex(1);
   }
 
   const containerVariants = {
@@ -83,12 +83,25 @@ setExpandedIndex(index);
         >
           <motion.div
             variants={imageVariants}
-            className={`relative h-full rounded-lg cursor-pointer transition-all duration-500 ${expandedIndex === 0 ? 'w-72 md:w-96' : 'w-24 md:w-28'}`}
+            className={`relative h-64 md:h-80 rounded-lg cursor-pointer transition-all duration-500 ${expandedIndex === 0 ? 'w-72 md:w-96' : 'w-24 md:w-28'}`}
             onMouseEnter={() => handleMouseEnter(0)}
+            onClick={() => setExpandedIndex(0)}
+            whileHover={{ scale: 1.02, rotate: expandedIndex !== 0 ? 2 : 0 }}
+            transition={{ duration: 0.3 }}
+            role="button"
+            tabIndex={0}
+            aria-label={t('imageText.processed')}
+            aria-pressed={expandedIndex === 0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setExpandedIndex(0);
+              }
+            }}
           >
             <Image
               src="/images/sliderimage1.png"
-              alt="Description 1"
+              alt="Processed products"
               layout="fill"
               objectFit="cover"
               className="rounded-lg"
@@ -104,12 +117,25 @@ setExpandedIndex(index);
           </motion.div>
           <motion.div
             variants={imageVariants}
-            className={`relative h-full rounded-lg cursor-pointer transition-all duration-500 ${expandedIndex === 1 ? 'w-72 md:w-96' : 'w-24 md:w-28'}`}
+            className={`relative h-64 md:h-80 rounded-lg cursor-pointer transition-all duration-500 ${expandedIndex === 1 ? 'w-72 md:w-96' : 'w-24 md:w-28'}`}
             onMouseEnter={() => handleMouseEnter(1)}
+            onClick={() => setExpandedIndex(1)}
+            whileHover={{ scale: 1.02, rotate: expandedIndex !== 1 ? 2 : 0 }}
+            transition={{ duration: 0.3 }}
+            role="button"
+            tabIndex={0}
+            aria-label={t('imageText.harvest')}
+            aria-pressed={expandedIndex === 1}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setExpandedIndex(1);
+              }
+            }}
           >
             <Image
               src="/images/sliderimage2.png"
-              alt="Description 2"
+              alt="Harvest time"
               layout="fill"
               objectFit="cover"
               className="rounded-lg"
@@ -125,12 +151,25 @@ setExpandedIndex(index);
           </motion.div>
           <motion.div
             variants={imageVariants}
-            className={`relative h-full rounded-lg cursor-pointer transition-all duration-500 ${expandedIndex === 2 ? 'w-72 md:w-96' : 'w-24 md:w-28'}`}
+            className={`relative h-64 md:h-80 rounded-lg cursor-pointer transition-all duration-500 ${expandedIndex === 2 ? 'w-72 md:w-96' : 'w-24 md:w-28'}`}
             onMouseEnter={() => handleMouseEnter(2)}
+            onClick={() => setExpandedIndex(2)}
+            whileHover={{ scale: 1.02, rotate: expandedIndex !== 2 ? 2 : 0 }}
+            transition={{ duration: 0.3 }}
+            role="button"
+            tabIndex={0}
+            aria-label={t('imageText.freshness')}
+            aria-pressed={expandedIndex === 2}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setExpandedIndex(2);
+              }
+            }}
           >
             <Image
               src="/images/sliderimage3.png"
-              alt="Description 3"
+              alt="Fresh produce"
               layout="fill"
               objectFit="cover"
               className="rounded-lg"


### PR DESCRIPTION
# Pull Request Overview

  ## 📝 Summary
  Enhanced the hero section gallery with interactive expandable cards,
  accessibility features, keyboard navigation, and smooth hover effects with
   rotation and elevation.

  ### 🪧 Related Issues
  - Closes #113 

  ### 🏁 Type of Change
  Mark with an `x` all the checkboxes that apply (like `[x]`).

  - [ ] 📝 Documentation (updates to README, docs, or comments)
  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] 👌 Enhancement (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing
  functionality to change)

  ### 🔄 Changes Made
  - Changed default expanded card from index 0 to index 1 (middle card)
  - Added onClick handlers to all three gallery cards for click-to-expand
  functionality
  - Implemented rotation (2°) and scale (1.02) effects on hover using
  framer-motion
  - Added comprehensive ARIA labels (role="button", aria-label,
  aria-pressed) for screen readers
  - Implemented keyboard navigation support (Enter and Space keys)
  - Fixed card height from `h-full` to `h-64 md:h-80` to ensure images
  display correctly

  ### 🚀 Implementation Details
  - **herosectionnew.tsx**: Updated `useState` default value from 0 to 1
  - **herosectionnew.tsx**: Added `onClick` handlers to each motion.div card
  - **herosectionnew.tsx**: Added `whileHover` props with scale and
  conditional rotation
  - **herosectionnew.tsx**: Added `role`, `tabIndex`, `aria-label`, and
  `aria-pressed` attributes
  - **herosectionnew.tsx**: Implemented `onKeyDown` handlers for Enter and
  Space key support
  - **herosectionnew.tsx**: Changed card heights from `h-full` to `h-64
  md:h-80` for proper rendering
  - **herosectionnew.tsx**: Updated `handleMouseLeave` to return to index 1
  instead of 0

  ### 🛠 Technical Notes
  - Uses framer-motion for smooth animations and hover effects
  - Rotation effect only applies to non-expanded cards (cleaner UX)
  - Maintains existing responsive design (horizontal scroll on mobile, hover
   on desktop)
  - All interactive elements are keyboard accessible with proper focus
  management
  - Images use Next.js Image component with layout="fill" for optimization

  ### ✅ Tests Results
  Manual testing performed to verify functionality

  ### Test Coverage
  - [ ] ✅ Unit Tests
  - [ ] 📨 Integration Tests
  - [x] 📟 Manual Testing

  ### 📸 Evidence
<img width="1654" height="671" alt="image" src="https://github.com/user-attachments/assets/f0e2502f-3544-4f26-86e6-b9c179424d98" />


  ### 🔍 Testing Notes
  - Verified that card expansion works on both hover and click
  - Tested keyboard navigation using Tab to focus and Enter/Space to
  activate
  - Confirmed rotation only applies to collapsed cards for better visual
  feedback
  - Checked ARIA attributes with browser developer tools
  - Tested on different viewport sizes for responsive behavior

  ### 🔜 Next Steps
  - Cross-browser compatibility testing (Chrome, Firefox, Safari)
  - Performance review of animation smoothness
  - Accessibility audit with screen reader testing
  - Mobile touch interaction testing




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Hero image tiles are now interactive with click and keyboard expand, hover animations, overlay descriptions, and a new default expanded card.
* Accessibility
  * Tiles behave as buttons with ARIA labels, keyboard support, and improved alt text.
* UI/Style
  * Updated hero tile sizing to fixed heights with refined spacing/animation timing.
  * Adjusted “Explore Marketplace” link label text.
* Localization
  * Updated Spanish translations structure for Producers sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->